### PR TITLE
update setup.py for python2.6 since it doesnt ship with argparse

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,5 +14,8 @@ setup(name="livestreamer",
       package_dir={'': 'src'},
       entry_points={
           "console_scripts": ['livestreamer=livestreamer.cli:main']
-      }
+      },
+      install_requires=[
+          'argparse',
+          ],
 )


### PR DESCRIPTION
Thanks for creating this awesome program! I wish it was more popular so I could've found it earlier instead of wasting my time & patience fiddling with rtmpdump

This fixes it so it runs with py2.6 out of the gate, tested on my ubu natty install
