### PR TITLE
'best' quality

### DIFF
--- a/src/livestreamer/plugins/__init__.py
+++ b/src/livestreamer/plugins/__init__.py
@@ -23,6 +23,16 @@ class Plugin(object):
         self.args = args
 
     def get_streams(self):
+        ranking = ['iphonelow', 'iphonehigh', '240p', '360p', '480p', '720p',
+                   'hd', '1080p', 'live']
+        streams = self._get_streams()
+        for rank in reversed(ranking):
+            if rank in streams:
+                streams['best'] = streams[rank]
+                break
+        return streams
+    
+    def _get_streams(self):
         raise NotImplementedError
 
 def load_plugins(plugins):

--- a/src/livestreamer/plugins/justintv.py
+++ b/src/livestreamer/plugins/justintv.py
@@ -69,7 +69,7 @@ class JustinTV(Plugin):
                 res.append(node.data)
         return "".join(res)
 
-    def get_streams(self):
+    def _get_streams(self):
         def clean_tag(tag):
             if tag[0] == "_":
                 return tag[1:]

--- a/src/livestreamer/plugins/ownedtv.py
+++ b/src/livestreamer/plugins/ownedtv.py
@@ -46,7 +46,7 @@ class OwnedTV(Plugin):
         if match:
             return int(match.group(1))
 
-    def get_streams(self):
+    def _get_streams(self):
         channelid = self._get_channel_id(self.url)
 
         if not channelid:

--- a/src/livestreamer/plugins/ustreamtv.py
+++ b/src/livestreamer/plugins/ustreamtv.py
@@ -23,7 +23,7 @@ class UStreamTV(Plugin):
         if match:
             return int(match.group(1))
 
-    def get_streams(self):
+    def _get_streams(self):
         def get_amf_value(data, key):
             pattern = ("{0}\W\W\W(.+?)\x00").format(key)
             match = re.search(bytes(pattern, "ascii"), data)


### PR DESCRIPTION
This allows the user to call

```
livestreamer url best
```

and automatically have the highest quality stream selected.

I have looked at a couple of livestreams of each of the implented platforms and decided (largely by gut feel) on this ranking

``` python
ranking = ['iphonelow', 'iphonehigh', '240p', '360p', '480p', '720p',
    'hd', '1080p', 'live']
```

based on the assumption that 'live' is the unadulterated stream from the broadcaster. Tested on my machine :)
