### PR TITLE
Add RawRtmp plugin.

### DIFF
--- a/src/livestreamer/plugins/rawrtmp.py
+++ b/src/livestreamer/plugins/rawrtmp.py
@@ -22,10 +22,15 @@ class RawRtmp(Plugin):
     def _parseOptions(self):
         options = {}
         optionsURL = self.url.split()
-        options['rtmp'] = optionsURL[0].strip()
+        options["rtmp"] = optionsURL[0].strip()
         for pv in optionsURL[1:]:
-            (param, value) = pv.split("=")
-            options[param.strip()] = value.strip()
+            if pv == "live":
+                options["live"] = True
+            elif pv == "realtime":
+                options["realtime"] = True
+            else:
+                index = pv.find('=')
+                options[pv[:index].strip()] = pv[index+1:].strip()
         return options
 
 


### PR DESCRIPTION
The RawRtmp plugin accepts all rtmp protocol that rtmpdump supports and passes them to RTMPStream.

Livestreamer works like a wrapper around rtmpdump and is quite useful if you are using livestreamer as a library.

Example: 

```
livestreamer rtmp://82.192.84.30:1935/live/myStream.sdp best
```
