### PR TITLE
Identify `best`, `worst` stream in the stream list

### DIFF
--- a/src/livestreamer/cli.py
+++ b/src/livestreamer/cli.py
@@ -306,9 +306,17 @@ def handle_url(args):
     if len(streams) == 0:
         exit("No streams found on this URL: {0}", args.url)
 
-    keys = list(streams.keys())
-    keys.sort()
-    validstreams = (", ").join(keys)
+    validstreams = ""
+    for name, stream in sorted(streams.items()):
+        if name in ("best", "worst"):
+            continue
+        validstreams += name
+        if stream is streams["best"]:
+            validstreams += " (best)"
+        if stream is streams["worst"]:
+            validstreams += " (worst)"
+        validstreams += ", "
+    validstreams = validstreams[:-2]
 
     if args.stream:
         if args.stream == "best" or args.stream == "worst":


### PR DESCRIPTION
> Print only best when both best and worst are the same stream (this is the case if there is only 1 stream available).

I argue that it's better to not omit `worst` (or `best` or both) if there's one stream because
- it's a deviation from a pattern that without considering external effects is a cost because of a more complex logic
- it has the external effect to invite a question "is worst not also a synonym for this stream?" that's without a clear answer
- the logical user reaction to this output is "it's a consistent pattern that the synonym is next to the stream" rather than "it's unnecessarily verbose to in this case too write the synonym for the stream".
