### PR TITLE
allow for people to use XDG_CONFIG_HOME

### DIFF
--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -174,6 +174,7 @@ is capable of reading arguments from a file instead, a sort of configuration fil
 Livestreamer will look for this file in different locations depending on your platform:
 
 **Unix-like OSs**
+  ``~/.config/livestreamer/config``
   ``~/.livestreamerrc``
 
 **Windows**

--- a/src/livestreamer_cli/constants.py
+++ b/src/livestreamer_cli/constants.py
@@ -25,7 +25,12 @@ else:
 if is_win32:
     RCFILE = os.path.join(os.environ["APPDATA"], "livestreamer", "livestreamerrc")
 else:
-    RCFILE = os.path.expanduser("~/.livestreamerrc")
+	XDGCONFIGHOME=os.environ.get('XDG_CONFIG_HOME')
+	if not XDGCONFIGHOME:
+		XDGCONFIGHOME="~/.config"
+	RCFILE = os.path.expanduser(XDGCONFIGHOME + "/livestreamer/config")
+	if not os.path.isfile(RCFILE):
+		RCFILE = os.path.expanduser("~/.livestreamerrc")
 
 
 EXAMPLE_USAGE = """


### PR DESCRIPTION
check if ~/.config/livestreamer/config exists before ~/.livestreamerrc
