### PR TITLE
Excluding streams of a protocol that's not in the priority list

### DIFF
--- a/src/livestreamer/plugin.py
+++ b/src/livestreamer/plugin.py
@@ -130,7 +130,8 @@ class Plugin(object):
 
                     streams[sname] = stream
             else:
-                streams[name] = stream
+                if type(stream).shortname() in priority:
+                    streams[name] = stream
 
         sort = sorted(filter(qualityweight, streams.keys()),
                       key=qualityweight)

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -47,7 +47,7 @@ class TestSession(unittest.TestCase):
 
     def test_plugin(self):
         channel = self.session.resolve_url("http://test.se/channel")
-        streams = channel.get_streams(priority=["http", "rtmp"])
+        streams = channel.get_streams()
 
         self.assertTrue("best" in streams)
         self.assertTrue("worst" in streams)


### PR DESCRIPTION
### Problem

This list all protocols

```
python -c "import livestreamer_cli.main; livestreamer_cli.main.main()" justin.tv/tsm_theoddone --stream-priority=rtmp
Found streams: 240p, 360p, 480p, 720p, 720p+ (best), mobile_high, mobile_low (worst)
```
### Solution

This list all `rtmp`

```
python -c "import livestreamer_cli.main; livestreamer_cli.main.main()" justin.tv/tsm_theoddone --stream-priority=rtmp
Found streams: 240p (worst), 360p, 480p, 720p, 720p+ (best)
```

This list all `rtmp` and `hls`

```
python -c "import livestreamer_cli.main; livestreamer_cli.main.main()" justin.tv/tsm_theoddone --stream-priority=rtmp,hls
Found streams: 240p, 360p, 480p, 720p, 720p+ (best), mobile_high, mobile_low (worst)
```
