### PR TITLE
handle SIGTERM like SIGINT (cli)

### DIFF
--- a/src/livestreamer_cli/main.py
+++ b/src/livestreamer_cli/main.py
@@ -1,6 +1,7 @@
 import errno
 import os
 import sys
+import signal
 
 from .argparser import parser
 from .compat import stdout, is_win32
@@ -372,6 +373,9 @@ def set_options(args):
 
 def main():
     arglist = sys.argv[1:]
+
+    # Handle SIGTERM just like SIGINT
+    signal.signal(signal.SIGTERM, signal.default_int_handler)
 
     # Load additional arguments from livestreamerrc
     if os.path.exists(CONFIG_FILE):


### PR DESCRIPTION
Killing livestreamer with SIGTERM while playing seems to cause some weird things, like being ignored (VLC keeps playing happily) or leaving children behind in the dust (like VLC locking up, eating up a whole core). I experience both, randomly.
