### PR TITLE
FilmOn Social TV: Adding support for live video

### DIFF
--- a/src/livestreamer/plugins/filmon_us.py
+++ b/src/livestreamer/plugins/filmon_us.py
@@ -1,0 +1,74 @@
+import re
+import requests
+
+from livestreamer.compat import urlparse
+from livestreamer.exceptions import PluginError, NoStreamsError
+from livestreamer.plugin import Plugin
+from livestreamer.stream import RTMPStream
+from livestreamer.utils import urlget
+
+RTMP_URL = "rtmp://204.107.26.73/battlecam"
+SWF_URL = "http://www.filmon.us/application/themes/base/flash/broadcast/VideoChatECCDN_debug_withoutCenteredOwner.swf"
+
+
+class Filmon_us(Plugin):
+    @classmethod
+    def can_handle_url(self, url):
+        return "filmon.us" in url
+
+    def _get_streams(self):
+        if not RTMPStream.is_usable(self.session):
+            raise PluginError("rtmpdump is not usable and required by Filmon_us plugin")
+
+        self.logger.debug("Fetching room_id")
+        self.rsession = requests.session()
+        res = urlget(self.url, session=self.rsession)
+
+        match = re.search("room/id/(\d+)", res.text)
+        if not match:
+            return
+        room_id = match.group(1)
+
+        self.logger.debug("Comparing channel name with URL")
+        match = re.search("<meta property=\"og:url\" content=\"http://www.filmon.us/(\w+)", res.text)
+        if not match:
+            return
+        channel_name = match.group(1)
+        base_name = self.url.rstrip("/").rpartition("/")[2]
+
+        if (channel_name != base_name):
+            return
+
+        streams = {}
+        try:
+            streams['default'] = self._get_stream(room_id)
+        except NoStreamsError:
+            pass
+
+        return streams
+
+    def _get_stream(self, room_id):
+        playpath = "mp4:bc_" + room_id
+        if not playpath:
+            raise NoStreamsError(self.url)
+
+        rtmp = RTMP_URL
+        parsed = urlparse(rtmp)
+        if not parsed.scheme.startswith("rtmp"):
+            raise NoStreamsError(self.url)
+
+        if parsed.query:
+            app = "{0}?{1}".format(parsed.path[1:], parsed.query)
+        else:
+            app = parsed.path[1:]
+
+        return RTMPStream(self.session, {
+            "rtmp": rtmp,
+            "pageUrl": self.url,
+            "swfUrl": SWF_URL,
+            "playpath": playpath,
+            "app": app,
+            "live": True
+        })
+
+__plugin__ = Filmon_us


### PR DESCRIPTION
## FilmOn Social TV: Adding support for live video
### Problem

This command

```
livestreamer filmon.us/alkidavid
```

return

```
error: No plugin can handle URL: filmon.us/alkidavid
```
### Solution

Adding support for http://www.filmon.us/channels
### Exception
#### Non-existing channel name

The URL http://filmon.us/no_channel return the same page as http://filmon.us/alkidavid rather than a 404

This command

```
livestreamer filmon.us/no_channel
```

return

```
error: No streams found on this URL: filmon.us/no_channel
```

by reading the channel name in this meta property

```
<meta property="og:url" content="http://www.filmon.us/alkidavid" />
```

because
- it's less confusing for the user that a non-existing channel return an error rather than the default channel "alkidavid"
## Live
### RTMP and SWF URL
#### Default URL

The values

```
RTMP_URL = "rtmp://204.107.26.73/battlecam"
SWF_URL = "http://www.filmon.us/application/themes/base/flash/broadcast/VideoChatECCDN_debug_withoutCenteredOwner.swf"
```

are in this packet

```
3167    6.144329000 192.168.5.130   204.107.26.73   RTMP    2009    Handshake C2 | connect('battlecam/')
```

The value

```
playpath = "mp4:bc_" + room_id
```

is in this packet

```
3533    7.052663000 192.168.5.130   204.107.26.73   RTMP    101 play('mp4:bc_3195397')
```

These packets are dentified with the Wireshark display filter

```
tcp.port == 1935
```
#### Alternative URL

There's no known alternative RTMP or SWF URL or a known API page that return the RTMP or SWF URL

The API page http://www.filmon.us/ajax accept these "action" requests

```
{"has_webcam":"0","room_id":"3195397","id":1,"controller":"broadcast","action":"userWebcamAvailabilityStatusUpdate"}
{"last_msg_id":0,"online_users":0,"room_id":"3195397","divId":1,"id":2,"controller":"broadcast","action":"getNewMessages"}
```

identified with the Wireshark display filter

```
http
```

but there's not a known request that return a RTMP or SWF URL
#### Quality

The channel quality is called "default" because
- there are no known alternative channel qualities
## Plugin name

The plugin name for the filmon.us streaming service should be

filmon.py (Filmon) rather than filmon_us.py (Filmon_us) because
- filmon.us share server or code with filmon.com

filmon_us.py (Filmon_us) rather than battlecam.py (Battlecam) because
- it's called FilmOn [Social TV](http://www.filmon.us/channels) since 2011. In a link at [FilmOn](http://www.filmon.us) that return a [page](http://www.filmon.us) with the title FilmOn rather than Battlecam
- FilmOn Social TV is a newer name for the service than Battlecam

battlecam.py (Battlecam) because 
- it was called [Battlecam](http://www.battlecam.com) when created in 2010
