### PR TITLE
YouTube plugin should accept youtu.be/id URLs

### DIFF
--- a/src/livestreamer/plugins/youtube.py
+++ b/src/livestreamer/plugins/youtube.py
@@ -8,7 +8,7 @@ import re
 class Youtube(Plugin):
     @classmethod
     def can_handle_url(self, url):
-        return "youtube.com" in url
+        return "youtube.com" in url or "youtu.be" in url
 
     @classmethod
     def stream_weight(cls, stream):


### PR DESCRIPTION
YouTube seems to gradually shift from "youtube.com/watch?v=xxx" URLs to "youtu.be/xxx".
