### PR TITLE
Add playback of first available video on the page

### DIFF
--- a/src/livestreamer/plugins/youtube.py
+++ b/src/livestreamer/plugins/youtube.py
@@ -45,6 +45,13 @@ class Youtube(Plugin):
     def _get_stream_info(self, url):
         res = urlget(url)
         config = self._find_config(res.text)
+        
+        if not config:
+            watch_match = re.search("href=\"/(watch\?v=.+?)\"", res.text)
+            if watch_match:
+                watch_url = "http://youtube.com/%s" % watch_match.group(1)
+                res = urlget(watch_url)
+                config = self._find_config(res.text)
 
         if config:
             return parse_json(config, "config JSON")


### PR DESCRIPTION
In case when you only provide a user profile url (e.g. http://www.youtube.com/esgn) this workaround scans for the first "/watch?" link available (if the user is live right now it will be a stream, otherwise a featured video)
