### PR TITLE
Document plain progressive HTTP as a streaming protocol

### DIFF
--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -262,6 +262,8 @@ Livestreamer currently supports these protocols:
 +-------------------------------+-----------------------------------------------+
 | Real Time Messaging Protocol  | rtmp:// rtmpe:// rtmps:// rtmpt:// rtmpte://  |
 +-------------------------------+-----------------------------------------------+
+| Progressive HTTP, HTTPS, etc  | httpstream://                                 |
++-------------------------------+-----------------------------------------------+
 
 
 .. _cli-options:


### PR DESCRIPTION
I noticed in Issue #304 it wasn’t actually documented
