### PR TITLE
Added plugin for NRK.

### DIFF
--- a/src/livestreamer/plugins/nrk.py
+++ b/src/livestreamer/plugins/nrk.py
@@ -1,0 +1,22 @@
+from livestreamer.exceptions import NoStreamsError
+from livestreamer.plugin import Plugin
+from livestreamer.stream import HLSStream
+from livestreamer.utils import urlget
+
+import re
+
+class NRK(Plugin):
+    @classmethod
+    def can_handle_url(self, url):
+        return 'tv.nrk.no' in url
+
+    def _get_streams(self):
+        self.logger.debug('Extracting media URL')
+        res = urlget(self.url, cookies = {'NRK_PLAYER_SETTINGS_TV':
+            'devicetype=desktop&preferred-player-odm=hlslink&preferred-player-live=hlslink'})
+        m = re.search(r'<div[^>]*?id="playerelement"[^>]+data-media="([^"]+)"', res.text)
+        if not m:
+            raise NoStreamsError(self.url)
+        return HLSStream.parse_variant_playlist(self.session, m.group(1))
+
+__plugin__ = NRK


### PR DESCRIPTION
Adds support for tv.nrk.no, NRK's streaming service. Works for both live and aired shows.

Live: `livestreamer http://tv.nrk.no/direkte/nrk1 best`

Other: `livestreamer http://tv.nrk.no/serie/nytt-paa-nytt/muhh29000714/21-02-2014 best`

(Streams may or may not be available from outside Norway due to copyright restrictions)
