### PR TITLE
include examples dir in source dist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -6,4 +6,5 @@ include LICENSE*
 include requirements-docs.txt
 
 recursive-include docs *
+recursive-include examples *
 recursive-include tests *py


### PR DESCRIPTION
The docs reference files in examples/ which are missing from the source dist,
thus producing a warning when building the docs from it.
