### PR TITLE
Fix ilive Plugin

### DIFF
--- a/src/livestreamer/plugins/ilive.py
+++ b/src/livestreamer/plugins/ilive.py
@@ -71,7 +71,7 @@ class ILive(Plugin):
             "live": True
         }
 
-        match = re.search("(http(s)?://.+/server.php\?id=\d+)",
+        match = re.search("(http(s)?://.+/server\d?.php\?id=\d+)",
                           res.text)
         if match:
             token_url = match.group(1)


### PR DESCRIPTION
Resolves #367

Token now is requested by server2.php, regular expression will match this now

Also mobile streams gone? or they need special plugin installed to work.
Maybe someone can install it and take a look at the traffic...
