### PR TITLE
Update install docs to point to OpenBSD packages.

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -67,6 +67,14 @@ OpenBSD
 
 Livestreamer is available in the `ports tree <http://openports.se/multimedia/livestreamer>`_:
 
+**Via package**
+
+.. code-block:: console
+
+    # pkg_add livestreamer
+
+**Via ports**
+
 .. code-block:: console
 
     # cd /usr/ports/multimedia/livestreamer


### PR DESCRIPTION
We strongly suggest users use packages instead of ports on OpenBSD. Add command to install livestreamer via OpenBSD packages.
