### PR TITLE
Parallel segment download (hls-download-threads).

### DIFF
--- a/src/livestreamer/session.py
+++ b/src/livestreamer/session.py
@@ -52,7 +52,8 @@ class Livestreamer(object):
             "rtmp-timeout": 60.0,
             "rtmp-rtmpdump": is_win32 and "rtmpdump.exe" or "rtmpdump",
             "rtmp-proxy": None,
-            "subprocess-errorlog": False
+            "subprocess-errorlog": False,
+            "hls-download-threads": 1
         })
         self.plugins = {}
         self.logger = Logger()

--- a/src/livestreamer/stream/hls.py
+++ b/src/livestreamer/stream/hls.py
@@ -105,7 +105,7 @@ class HLSStreamWriter(SegmentedStreamWriter):
         else:
             content = res.content
 
-        self.reader.buffer.write(content)
+        self.reader.buffer.write(content, sequence.num) # For the order.
         self.logger.debug("Download of segment {0} complete", sequence.num)
 
 class HLSStreamWorker(SegmentedStreamWorker):

--- a/src/livestreamer_cli/argparser.py
+++ b/src/livestreamer_cli/argparser.py
@@ -620,6 +620,14 @@ transport.add_argument(
     Useful when debugging rtmpdump related issues.
     """
 )
+transport.add_argument("--hls-download-threads",
+    type=int,
+    help="""
+    How many threads spawn to download hls segments in parallel.
+
+    Default is 1
+    """
+)
 
 
 http = parser.add_argument_group("HTTP options")

--- a/src/livestreamer_cli/main.py
+++ b/src/livestreamer_cli/main.py
@@ -697,6 +697,9 @@ def setup_options():
     if args.rtmp_timeout:
         livestreamer.set_option("rtmp-timeout", args.rtmp_timeout)
 
+    if args.hls_download_threads:
+        livestreamer.set_option("hls-download-threads", args.hls_download_threads)
+
     livestreamer.set_option("subprocess-errorlog", args.subprocess_errorlog)
 
     # Deprecated options


### PR DESCRIPTION
Added an option to set a number of threads to download segments in
parallel.

Use case: ISP gives good bandwidth but limits each http transfer (QoS, caps, etc)
to a very low speed, which sometimes causes lost segments due to timeouts
or just plain taking too long to download the first segments.
This way at least no segment is lost.
