### PR TITLE
Add ~/Applications to search path for VLC

### DIFF
--- a/src/livestreamer_cli/utils.py
+++ b/src/livestreamer_cli/utils.py
@@ -183,6 +183,7 @@ def find_default_player():
     if "darwin" in sys.platform:
         paths = os.environ.get("PATH", "").split(":")
         paths += ["/Applications/VLC.app/Contents/MacOS/"]
+        paths += ["~/Applications/VLC.app/Contents/MacOS/"]
         path = check_paths(("VLC", "vlc"), paths)
     elif "win32" in sys.platform:
         exename = "vlc.exe"


### PR DESCRIPTION
This adds the ~/Applications` to the search path for the VLC.app on Darwin (Mac OS X).
It's for those that have installed VLC to their account only.

I use [homebrew casks](http://caskroom.io) and it installed VLC to my own Applications folder, but this also happens if you aren't administrator, or probably for a multitude of other reasons I can't think of right now.
