### PR TITLE
plugin.gaminglive: basic support for gaming live

### DIFF
--- a/src/livestreamer/plugins/gaminglive.py
+++ b/src/livestreamer/plugins/gaminglive.py
@@ -10,7 +10,7 @@ QUALITY_WEIGHTS = {
     "low": 1,
 }
 CHANNELS_API = "http://api.gaminglive.tv/channels/{0}"
-_url_re = re.compile("http(s)?://staging.gaminglive.tv/\#/channels/(?P<channel>[^/]+)", re.VERBOSE)
+_url_re = re.compile("http(s)?://(staging|alpha)\.gaminglive\.tv/\#/channels/(?P<channel>[^/]+)", re.VERBOSE)
 
 
 class GamingLive(Plugin):


### PR DESCRIPTION
My first attempt to do something beyond "Hello World" in Python.

GamingLive.TV is a new streaming portal which is in a somewhat closed alpha state right now. You can't register as new user and streamers are invited by GamingLive directly.

The plugin supports live-streams only (i believe there are no VODs at the moment). No special parameters or configuration. You just type:

```
livestreamer http://staging.gaminglive.tv/#/channels/h4r live
```

Since it is a new platform there not many streamers at any given time. You can get a list of all live broadcasters with this url:

```
http://staging.gaminglive.tv/#/channels
```

The code should be straight forward. I don't like the way i handled the JSON response (lots of `if not ... return`). I tried to use your schema validation API but i did not understand it enough to make it work.

As i said i have close to no experience with Python so any additional comment would be greatly appreciated. 

And also this is my first pull-request, if i did anything wrong please let me know.

Thanks.
