### PR TITLE
plugins.gaminglive: fix "No data returned from stream" issue

### DIFF
--- a/src/livestreamer/plugins/gaminglive.py
+++ b/src/livestreamer/plugins/gaminglive.py
@@ -4,6 +4,7 @@ from livestreamer.plugin import Plugin
 from livestreamer.plugin.api import http, validate
 from livestreamer.stream import RTMPStream
 
+SWF_URL = "http://alpha.gaminglive.tv/lib/flowplayer/flash/flowplayer.commercial-3.2.18.swf"
 CHANNELS_API_URL = "http://api.gaminglive.tv/channels/{0}"
 QUALITY_WEIGHTS = {
     "live": 3,
@@ -65,7 +66,9 @@ class GamingLive(Plugin):
             stream = RTMPStream(self.session, {
                 "rtmp": json["stream"]["rootUrl"],
                 "playpath": quality,
-                "pageUrl": self.url
+                "pageUrl": self.url,
+                "swfVfy": SWF_URL,
+                "live": True
             })
             streams[stream_name] = stream
 


### PR DESCRIPTION
The plugin stopped working. I took me some guess work but adding the SWF-player to the created RTMPStream seems to fix it.

Also, i hope my line endings are now okay :-)
