### PR TITLE
plugins.gaminglive: adapted to work with old and new quality labels

### DIFF
--- a/src/livestreamer/plugins/gaminglive.py
+++ b/src/livestreamer/plugins/gaminglive.py
@@ -7,9 +7,14 @@ from livestreamer.stream import RTMPStream
 SWF_URL = "http://www.gaminglive.tv/lib/flowplayer/flash/flowplayer.commercial-3.2.18.swf"
 CHANNELS_API_URL = "http://api.gaminglive.tv/channels/{0}"
 QUALITY_WEIGHTS = {
-    "live": 3,
+    "source": 5,
+    "live": 5,
+    "1080": 4,
+    "720": 3,
+    "480": 2,
     "medium": 2,
-    "low": 1,
+    "360": 1,
+    "low": 1
 }
 
 _url_re = re.compile("""


### PR DESCRIPTION
GamingLive.TV changed their stream quality labels. So i modified the plugin to work with both, the old and new labels. Sorting and "best" and "worst" stream quality determination works again.
