### PR TITLE
Plugin be-at.tv: Schema offset can be float or int 

### DIFF
--- a/src/livestreamer/plugins/beattv.py
+++ b/src/livestreamer/plugins/beattv.py
@@ -50,12 +50,12 @@ _schema = validate.Schema(
             "status": int,
             "media": [{
                 "duration": validate.any(float, int),
-                "offset": int,
+                "offset": validate.any(float, int),
                 "id": int,
                 "parts": [{
                     "duration": validate.any(float, int),
                     "id": int,
-                    "offset": int,
+                    "offset": validate.any(float, int),
                     validate.optional("recording"): int,
                     validate.optional("start"): validate.any(float, int)
                 }]


### PR DESCRIPTION
For the be-at.tv plugin, the offset needs to be validated as `float, int` rather than just `int`. An example of a stream which uses a float offset is: `http://www.be-at.tv/brands/o2-academy/o2-academy-brixton/hospital-we-are-18/etherwood-sp-mc`

Thanks
