### PR TITLE
Plugin veetle: fix streams for shorturls.

### DIFF
--- a/src/livestreamer/plugins/veetle.py
+++ b/src/livestreamer/plugins/veetle.py
@@ -32,6 +32,8 @@ class Veetle(Plugin):
         parsed = urlparse(self.url)
         if parsed.fragment:
             channel_id = parsed.fragment
+        elif parsed.path[:3] == '/v/':
+            channel_id = parsed.path.split('/')[-1]
         else:
             channel_id = match.group("channel")
 


### PR DESCRIPTION
As discussed in https://github.com/chrippa/livestreamer/issues/537.
