### PR TITLE
Fix vaughnlive.tv

### DIFF
--- a/src/livestreamer/plugins/vaughnlive.py
+++ b/src/livestreamer/plugins/vaughnlive.py
@@ -5,17 +5,12 @@ from livestreamer.plugin.api import http, validate
 from livestreamer.stream import RTMPStream
 
 INFO_URL = "http://mvn.vaughnsoft.net/video/edge/{domain}_{channel}"
-SWF_URL = "http://vaughnlive.tv/800021294/swf/VaughnSoftPlayer.swf"
 
 DOMAIN_MAP = {
     "breakers": "btv",
     "vapers": "vtv",
     "vaughnlive": "live",
 }
-
-DEBUG_PORT_ID = 84
-SECURE_TOKEN = "30dabc4871922a1314192e925ab7961d"
-SET_GEO_CODE = 5
 
 _url_re = re.compile("""
     http(s)?://(\w+\.)?
@@ -26,25 +21,18 @@ _channel_not_found_re = re.compile("<title>Channel Not Found")
 
 
 def decode_token(token):
-    def decode_part(part):
-        part = int(part.replace("0m0", ""))
-        part /= DEBUG_PORT_ID
-        part /= SET_GEO_CODE
-        return chr(int(part))
-
-    return "".join(decode_part(part) for part in token.split(":"))
-
+    return token.replace("0m0", "")
 
 _schema = validate.Schema(
-    validate.transform(lambda s: s.split(";")),
-    validate.length(3),
+    validate.transform(lambda s: s.split(";:mvnkey%")),
+    validate.length(2),
     validate.union({
         "server": validate.all(
             validate.get(0),
             validate.text
         ),
         "token": validate.all(
-            validate.get(2),
+            validate.get(1),
             validate.text,
             validate.transform(decode_token)
         )
@@ -66,15 +54,15 @@ class VaughnLive(Plugin):
         params = match.groupdict()
         params["domain"] = DOMAIN_MAP.get(params["domain"], params["domain"])
         info = http.get(INFO_URL.format(**params), schema=_schema)
+        swfUrl = "http://vaughnlive.tv" + re.compile('swfobject.embedSWF\("(/\d+/swf/[0-9A-Za-z]+\.swf)"').findall(res.text)[0]
 
         stream = RTMPStream(self.session, {
             "rtmp": "rtmp://{0}/live".format(info["server"]),
             "app": "live?{0}".format(info["token"]),
-            "swfVfy": SWF_URL,
+            "swfVfy": swfUrl,
             "pageUrl": self.url,
             "live": True,
             "playpath": "{domain}_{channel}".format(**params),
-            "token": SECURE_TOKEN
         })
 
         return dict(live=stream)


### PR DESCRIPTION
fixes #575 

Looking at [this xbmc plugin](https://github.com/HIGHWAY99/plugin.stream.vaughnlive.tv/blob/master/default.py#L248) and its [info file](https://github.com/HIGHWAY99/plugin.stream.vaughnlive.tv/blob/master/info-vaughnlive.tv.txt) referenced by @potentate, it doesn't seem the secure_token, port, and geo_code variables are needed anymore. It also seems the swf url is given in the response, so I took their approach and used that in the rtmp request.

The video token format seems to have changed from [this](https://github.com/HIGHWAY99/plugin.stream.vaughnlive.tv/blob/master/info-vaughnlive.tv.txt#L46) to `[ip]:[port];:mvnkey%[token]`, and doesn't require any of the transformations used previously to make it work.
