### PR TITLE
Support for more types of Youtube URLs

### DIFF
--- a/src/livestreamer/plugins/youtube.py
+++ b/src/livestreamer/plugins/youtube.py
@@ -1,5 +1,5 @@
 import re
-import urllib
+from livestreamer.compat import unquote
 
 from livestreamer.plugin import Plugin, PluginError
 from livestreamer.plugin.api import http, validate
@@ -108,7 +108,7 @@ _url_re = re.compile("""
 class YouTube(Plugin):
     @classmethod
     def can_handle_url(self, url):
-        return _url_re.match(urllib.unquote(url))
+        return _url_re.match(unquote(url))
 
     @classmethod
     def stream_weight(cls, stream):
@@ -144,7 +144,7 @@ class YouTube(Plugin):
             return video_id
 
     def _get_stream_info(self, url):
-        match = _url_re.match(urllib.unquote(url))
+        match = _url_re.match(unquote(url))
         user = match.group("user")
 
         if user:


### PR DESCRIPTION
Came across links like this http://www.youtube.com/attribution_link?a=vWY_P7tULpw&u=%2Fwatch%3Fv%3DlmpBiqX_DTY%26feature%3Dshare (and http://youtu.be/CSyIrrKhJQQ while testing my modifications). The short links work with making the "watch/embed/v" part optional. Decoding the attribution links seemed the easiest way to make them work. So far, everything I've tried plays now.
