### PR TITLE
cli: add option to server streams externally without a player

### DIFF
--- a/src/livestreamer_cli/argparser.py
+++ b/src/livestreamer_cli/argparser.py
@@ -354,6 +354,32 @@ player.add_argument(
     """
 )
 player.add_argument(
+    "--player-external-http",
+    action="store_true",
+    help="""
+    Serve stream data through HTTP without running any player. This is useful
+    to allow external devices like smartphones or streaming boxes to watch
+    streams they wouldn't be able to otherwise.
+
+    Behavior will be similar to the continuous HTTP option, but no player
+    program will be started, and the server will listen on all available
+    connections instead of just in the local (loopback) interface.
+
+    The URLs that can be used to access the stream will be printed to the
+    console, and the server can be interrupted using CTRL-C.
+    """
+)
+player.add_argument(
+    "--player-external-http-port",
+    metavar="PORT",
+    type=num(int, min=0, max=65535),
+    default=0,
+    help="""
+    A fixed port to use for the external HTTP server if that mode is enabled.
+    Omit or set to 0 to use a random high (>1024) port.
+    """
+)
+player.add_argument(
     "--player-passthrough",
     metavar="TYPES",
     type=comma_list_filter(STREAM_PASSTHROUGH),


### PR DESCRIPTION
Add an option to the CLI name --player-external-http, to start an HTTP
server like --player-continuous-http, but without starting a
corresponding player, and streaming to all available interfaces instead
of just the loopback.

This can be useful to stream to devices like smartphones or streaming
boxes, while making use of the better compatibility and performance of
livestreamer.

An accompanying --player-external-http-port option was added to allow
people behind firewalls to add their exceptions only once.

When starting livestreamer in this mode, URLs for the server will be
printed instead of a player being started. Those are detected based
on the IPv4 addresses returned by calling
socket.getaddrinfo(socket.gethostname(), ...), which will work for sure
on UNIX platforms, and should on Windows as well (actual testing
pending), in addition to 127.0.0.1.