### PR TITLE
plugins.veetle: simple redirect fix

### DIFF
--- a/src/livestreamer/plugins/veetle.py
+++ b/src/livestreamer/plugins/veetle.py
@@ -28,6 +28,7 @@ class Veetle(Plugin):
         return _url_re.match(url)
 
     def _get_streams(self):
+        self.url = http.resolve_url(self.url)
         match = _url_re.match(self.url)
         parsed = urlparse(self.url)
         if parsed.fragment:


### PR DESCRIPTION
closes #752.

current veetle "short url" returns a http 301 moved permanently response; resolve_url the needed url before matching/etc.