### PR TITLE
plugins.gaminglive: VOD support fixed

### DIFF
--- a/src/livestreamer/plugins/gaminglive.py
+++ b/src/livestreamer/plugins/gaminglive.py
@@ -93,7 +93,7 @@ class GamingLive(Plugin):
             return
 
         streams = {}
-        streams[json["title"]] = self._create_rtmp_stream(VOD_RTMP_URL.format(json["channel_slug"]), json["name"], False)
+        streams["source"] = self._create_rtmp_stream(VOD_RTMP_URL.format(json["channel_slug"]), json["name"], True)
 
         return streams
 


### PR DESCRIPTION
For some reason we have to create the RTMPStream with "live" = True for
VODs too or they won't play. I also changed the name of the VOD quality
from the video title to "source". It made more sense to me.