### PR TITLE
Fix crunchyroll api auth

### DIFF
--- a/src/livestreamer/plugins/crunchyroll.py
+++ b/src/livestreamer/plugins/crunchyroll.py
@@ -9,16 +9,16 @@ from livestreamer.stream import HLSStream
 
 API_URL = "https://api.crunchyroll.com/{0}.0.json"
 API_HEADERS = {
-    "User-Agent": "Mozilla/5.0 (PLAYSTATION 3; 4.46)",
+    "User-Agent": "Mozilla/5.0 (iPhone; iPhone OS 8.3.0; en_US)",
     "Host": "api.crunchyroll.com",
     "Accept-Encoding": "gzip, deflate",
     "Accept": "*/*",
     "Content-Type": "application/x-www-form-urlencoded"
 }
-API_VERSION = "1.0.1"
+API_VERSION = "2313.8"
 API_LOCALE = "enUS"
-API_ACCESS_TOKEN = "S7zg3vKx6tRZ0Sf"
-API_DEVICE_TYPE = "com.crunchyroll.ps3"
+API_ACCESS_TOKEN = "QWjz212GspMHH9h"
+API_DEVICE_TYPE = "com.crunchyroll.iphone"
 STREAM_WEIGHTS = {
     "low": 240,
     "mid": 420,


### PR DESCRIPTION
The PS3 API tokens seem to have changed. Modified the auth token and headers we send to fix that. See this [commit](https://github.com/MattRK/Crunchyroll.bundle/commit/17b5fe83a0982cf5c49a8b8de5bfa27012fe6832) for the related change on the flex plugin.

Fixes #864

*Note:* not sure if I should be sending this pull request against master, since it's pretty urgent. Let me know in any case if you need me to change it.