### PR TITLE
fix vaughnlive plugin #897

### DIFF
--- a/src/livestreamer/plugins/vaughnlive.py
+++ b/src/livestreamer/plugins/vaughnlive.py
@@ -24,7 +24,7 @@ def decode_token(token):
     return token.replace("0m0", "")
 
 _schema = validate.Schema(
-    validate.transform(lambda s: s.split(";:mvnkey%")),
+    validate.transform(lambda s: s.split(";:mvnkey-")),
     validate.length(2),
     validate.union({
         "server": validate.all(


### PR DESCRIPTION
fixes  #897

vaughnlive changed a delimiter in their api, updated the plugin accordingly.

tested with all three sites supported by the plugin (vaugnlive.tv, breakers.tv, vapers.tv)