### PR TITLE
Plugin for Expressen

### DIFF
--- a/docs/plugin_matrix.rst
+++ b/docs/plugin_matrix.rst
@@ -36,6 +36,7 @@ douyutv             douyutv.com          Yes   --
 dmcloud             api.dmcloud.net      Yes   --
 drdk                dr.dk                Yes   Yes   Streams may be geo-restricted to Denmark.
 euronews            euronews.com         Yes   No
+expressen           expressen.se         Yes   Yes
 filmon              filmon.com           Yes   Yes   Only SD quality streams.
 filmon_us           filmon.us            Yes   Yes
 furstream           furstre.am           Yes   No

--- a/src/livestreamer/plugins/expressen.py
+++ b/src/livestreamer/plugins/expressen.py
@@ -46,7 +46,7 @@ class Expressen(Plugin):
                     params = {
                         "rtmp": vurl_el.text,
                     }
-                    streams.update({name: RTMPStream(self.session, params)})
+                    streams[name] = RTMPStream(self.session, params)
                     
         parsed_urls = set()
         mobileurls_el = parsed_info.find("mobileurls");
@@ -64,7 +64,7 @@ class Expressen(Plugin):
                 
                 if url[0] == "http" and url[2].endswith("m3u8"):
                     streams.update(HLSStream.parse_variant_playlist(self.session, text))
-                    
+        
         return streams
 
 __plugin__ = Expressen

--- a/src/livestreamer/plugins/expressen.py
+++ b/src/livestreamer/plugins/expressen.py
@@ -1,0 +1,71 @@
+import re
+from livestreamer.compat import urlparse
+from livestreamer.plugin import Plugin
+from livestreamer.plugin.api import http
+from livestreamer.plugin.api.utils import parse_xml
+from livestreamer.stream import HDSStream, HLSStream, RTMPStream
+
+
+VIDEO_INFO_URL = "http://www.expressen.se/Handlers/WebTvHandler.ashx?id={0}";
+
+_url_re = re.compile("http(s)?://(?:\w+.)?\.expressen\.se")
+_meta_xmlurl_id_re = re.compile('<meta.+xmlUrl=http%3a%2f%2fwww.expressen.se%2fHandlers%2fWebTvHandler.ashx%3fid%3d([0-9]*)" />')
+
+
+class Expressen(Plugin):
+    @classmethod
+    def can_handle_url(cls, url):
+        return _url_re.match(url)
+
+    def _get_streams(self):
+        res = http.get(self.url)
+        
+        match = _meta_xmlurl_id_re.search(res.text)
+        if not match:
+            return;
+        
+        xml_info_url = VIDEO_INFO_URL.format(match.group(1))
+        video_info_res = http.get(xml_info_url)
+        parsed_info = parse_xml(video_info_res.text)
+        
+        streams = { }
+        
+        live_el = parsed_info.find("live");
+        live = live_el is not None and live_el.text == "1"
+        
+        hdsurl_el = parsed_info.find("hdsurl");
+        if hdsurl_el is not None and hdsurl_el.text is not None:
+            hdsurl = hdsurl_el.text
+            streams.update(HDSStream.parse_manifest(self.session, hdsurl))
+            
+        if live:
+            vurls_el = parsed_info.find("vurls");
+            if vurls_el is not None:
+                for i, vurl_el in enumerate(vurls_el):
+                    bitrate = vurl_el.get("bitrate")
+                    name = bitrate + "k" if bitrate is not None else "rtmp{0}".format(i)
+                    params = {
+                        "rtmp": vurl_el.text,
+                    }
+                    streams.update({name: RTMPStream(self.session, params)})
+                    
+        parsed_urls = set()
+        mobileurls_el = parsed_info.find("mobileurls");
+        if mobileurls_el is not None:
+            for mobileurl_el in mobileurls_el:
+                text = mobileurl_el.text
+                if not text:
+                    continue
+                
+                if text in parsed_urls:
+                    continue
+                
+                mobileurls_el.add(text)
+                url = urlparse(text)
+                
+                if url[0] == "http" and url[2].endswith("m3u8"):
+                    streams.update(HLSStream.parse_variant_playlist(self.session, text))
+        
+        return streams
+
+__plugin__ = Expressen


### PR DESCRIPTION
Hi, had a go at a plugin for Expressen.

Some rationale:
The HDS manifest is only linked on VODs, on live streams the tag exists but is a void element => still look for it should it change in the future. VODs have one RTMP stream linked, which never seems to work (no data received) => skip RTMP when not live (live streams do have multiple working RTMP streams). The mobile URLs have one RTSP stream, the rest are HLS master playlists => only look for scheme=http, file=m3u8, skip rest. The mobile URLs are sometimes identical, hence the set.

I wasn't sure how the RTMP streams should be named should the bitrate be missing since then there would be zero metadata. Should additional RTMP parameters be added? e.g. live, pageUrl