### PR TITLE
GoodGame URL parse fix

### DIFF
--- a/src/livestreamer/plugins/goodgame.py
+++ b/src/livestreamer/plugins/goodgame.py
@@ -12,7 +12,7 @@ QUALITIES = {
     "240p": "_240"
 }
 
-_url_re = re.compile("http://(?:www\.)?goodgame.ru/channel/(?P<user>\w+)/")
+_url_re = re.compile("http://(?:www\.)?goodgame.ru/channel/(?P<user>\w+)")
 _stream_re = re.compile(
     "iframe frameborder=\"0\" width=\"100%\" height=\"100%\" src=\"http://goodgame.ru/player(\d)?\?(\d+)\""
 )


### PR DESCRIPTION
URL can be without trailing slash. Example: http://goodgame.ru/channel/test
In that case livestreamer will fail to found plugin and that is confusing.