### PR TITLE
azubutv: set video_player to None if stream is offline

### DIFF
--- a/src/livestreamer/plugins/azubutv.py
+++ b/src/livestreamer/plugins/azubutv.py
@@ -146,6 +146,7 @@ class AzubuTV(Plugin):
             video_player = "ref:" + stream_video['reference_id']
         else:
             is_live = False
+            video_player = None
 
         player_id = channel_info['player_id']
 


### PR DESCRIPTION
This prevents an error with traceback and instead just prints "No streams
found" like it should if the stream in question is not live. Fixes #1083.
