### PR TITLE
Use signature if getargspec is not available.

### DIFF
--- a/src/livestreamer/packages/flashmedia/types.py
+++ b/src/livestreamer/packages/flashmedia/types.py
@@ -3,7 +3,7 @@ from .util import pack_bytes_into
 
 from collections import namedtuple
 from struct import Struct, error as struct_error
-from inspect import getargspec
+import inspect
 
 (SCRIPT_DATA_TYPE_NUMBER, SCRIPT_DATA_TYPE_BOOLEAN,
  SCRIPT_DATA_TYPE_STRING, SCRIPT_DATA_TYPE_OBJECT,
@@ -1037,7 +1037,20 @@ class AMF3ObjectBase(object):
             amfcls.__name__ = name
 
             if not amfcls.__members__:
-                amfcls.__members__ = getargspec(amfcls.__init__).args[1:]
+                try:
+                    normalargs = inspect.getargspec(amfcls.__init__).args
+                except AttributeError:
+                    allparameters = (inspect
+                                     .signature(amfcls.__init__)
+                                     .parameters
+                                     .values())
+                    def normalargp(arg):
+                        return arg.kind == arg.POSITIONAL_OR_KEYWORD
+                    normalargs = [parameter.name
+                                  for parameter
+                                  in allparameters
+                                  if normalargp(parameter)]
+                anfcls.__members__ = normalargs[1:]
 
             cls._registry[name] = amfcls
 

--- a/src/livestreamer/stream/http.py
+++ b/src/livestreamer/stream/http.py
@@ -6,6 +6,7 @@ from .stream import Stream
 from .wrappers import StreamIOThreadWrapper, StreamIOIterWrapper
 from ..exceptions import StreamError
 
+from collections import namedtuple
 
 def normalize_key(keyval):
     key, val = keyval
@@ -15,7 +16,20 @@ def normalize_key(keyval):
 
 
 def valid_args(args):
-    argspec = inspect.getargspec(requests.Request.__init__)
+    try:
+        argspec = inspect.getargspec(requests.Request.__init__)
+    except AttributeError:
+        allparameters = (inspect
+                         .signature(requests.Request.__init__)
+                         .parameters
+                         .values())
+        ArgspecShim = namedtuple('ArgspecShim', ['args'])
+        def normalargp(arg):
+            return arg.kind == arg.POSITIONAL_OR_KEYWORD
+        argspec = ArgspecShim([parameter.name
+                               for parameter
+                               in allparameters
+                               if normalargp(parameter)])
 
     return dict(filter(lambda kv: kv[0] in argspec.args, args.items()))
 


### PR DESCRIPTION
Fix #1074.

This fix lets the program work on Python 3.6 and higher, where
inspect.getargspec has been deprecated.
