### PR TITLE
plugin: added media_ccc_de api and protocol changes

### DIFF
--- a/src/livestreamer/plugins/media_ccc_de.py
+++ b/src/livestreamer/plugins/media_ccc_de.py
@@ -26,15 +26,15 @@ from livestreamer.plugin.api import http
 from livestreamer.stream import HTTPStream, HLSStream
 
 API_URL_MEDIA           = "https://api.media.ccc.de"
-API_URL_STREAMING_MEDIA = "http://streaming.media.ccc.de/streams/v1.json"
+API_URL_STREAMING_MEDIA = "https://streaming.media.ccc.de/streams/v1.json"
 
 # http(s)://media.ccc.de/path/to/talk.html
 _url_media_re           = re.compile("(?P<scheme>http|https)"
                                      ":\/\/"
                                      "(?P<server>media\.ccc\.de)"
-                                     "\/.*\.html")
-# http://streaming.media.ccc.de/room/
-_url_streaming_media_re = re.compile("(?P<scheme>http)"
+                                     "\/")
+# https://streaming.media.ccc.de/room/
+_url_streaming_media_re = re.compile("(?P<scheme>http|https)"
                                      ":\/\/"
                                      "(?P<server>streaming\.media\.ccc\.de)"
                                      "\/"


### PR DESCRIPTION
* the media.ccc.de url scheme was changed after upgrading to a new frontend
* streaming.media.ccc.de supports also https