### PR TITLE
Fix crashes on HTTPServer's SIGPIPE

### DIFF
--- a/src/livestreamer_cli/utils/http_server.py
+++ b/src/livestreamer_cli/utils/http_server.py
@@ -83,10 +83,13 @@ class HTTPServer(object):
             conn.close()
             raise OSError("Invalid request method: {0}".format(req.command))
 
-        conn.send(b"HTTP/1.1 200 OK\r\n")
-        conn.send(b"Server: Livestreamer\r\n")
-        conn.send(b"Content-Type: video/unknown\r\n")
-        conn.send(b"\r\n")
+        try:
+            conn.send(b"HTTP/1.1 200 OK\r\n")
+            conn.send(b"Server: Livestreamer\r\n")
+            conn.send(b"Content-Type: video/unknown\r\n")
+            conn.send(b"\r\n")
+        except socket.error:
+            raise OSError("Failed to write data to socket")
 
         # We don't want to send any data on HEAD requests.
         if req.command == "HEAD":


### PR DESCRIPTION
##### Case in point
Working on a project of my own that uses Livestreamer, I stumbled upon [an issue](https://github.com/best-coloc-ever/twitch-cast/issues/10) while using the `--player-external-http` option

Basically, if a socket sends an HTTP request and closes before Livestreamer's HTTP server sends the response, consequent calls to `send` on the socket will send a `SIGPIPE` to Livestreamer's process which will raise a `socket.error` exception that was currently not caught.

[Possible environment to reproduce](https://github.com/best-coloc-ever/twitch-cast/blob/master/streamer%2FDockerfile)
For example, running this command:
```sh
livestreamer twitch.tv/dotamajor best \
    --player-external-http \
    --player-external-http-port 12345
```
Followed by this little script:
```sh
while true; do 
    curl http://localhost:12345 &> /dev/null & sleep .5 && kill $! ;
done
``` 

Will make the first command crash after a short time with an output like:
```
[cli][info] Found matching plugin twitch for URL twitch.tv/dotamajor
[cli][info] Available streams: audio, high, low, medium, mobile (worst), source (best)
[cli][info] Starting server, access with one of:
[cli][info]  http://127.0.0.1:12345/
[cli][info]  http://172.17.0.2:12345/
[cli][info] Got HTTP request from curl/7.35.0
[cli][info] Opening stream: source (hls)
[cli][info] HTTP connection closed
[cli][info] Stream ended
[cli][info] Got HTTP request from curl/7.35.0
[cli][info] Opening stream: source (hls)
[cli][info] HTTP connection closed
[cli][info] Stream ended
Traceback (most recent call last):
  File "/usr/local/bin/livestreamer", line 9, in <module>
    load_entry_point('livestreamer==1.12.2', 'console_scripts', 'livestreamer')()
  File "/usr/local/lib/python2.7/dist-packages/livestreamer_cli/main.py", line 885, in main
    handle_url()
  File "/usr/local/lib/python2.7/dist-packages/livestreamer_cli/main.py", line 490, in handle_url
    handle_stream(plugin, streams, stream_name)
  File "/usr/local/lib/python2.7/dist-packages/livestreamer_cli/main.py", line 371, in handle_stream
    port=args.player_external_http_port)
  File "/usr/local/lib/python2.7/dist-packages/livestreamer_cli/main.py", line 152, in output_stream_http
    for req in iter_http_requests(server, player):
  File "/usr/local/lib/python2.7/dist-packages/livestreamer_cli/main.py", line 118, in iter_http_requests
    yield server.open(timeout=2.5)
  File "/usr/local/lib/python2.7/dist-packages/livestreamer_cli/utils/http_server.py", line 87, in open
    conn.send(b"Server: Livestreamer\r\n")
socket.error: [Errno 32] Broken pipe
```

##### Resolution

I just added a `try-except` block around the code that was calling `send` on the client's socket and forwarded the exception as an `OSError`
Those are [ignored at an upper level in the call stack](https://github.com/chrippa/livestreamer/blob/v1.12.2/src/livestreamer_cli/main.py#L118-L121) so no more crashes