### PR TITLE
plugins.picarto: Update url regex

### DIFF
--- a/src/livestreamer/plugins/picarto.py
+++ b/src/livestreamer/plugins/picarto.py
@@ -5,12 +5,7 @@ from livestreamer.stream import RTMPStream
 
 RTMP_URL = "rtmp://live.us.picarto.tv/golive/{0}"
 
-_url_re = re.compile("""
-    http(s)?://(\w+\.)?picarto.tv
-    /live/(channel|channelhd|multistream).php
-    .+watch=(?P<channel>[^&?/]+)
-""", re.VERBOSE)
-
+_url_re = re.compile("http(s)?://(\w+\.)?picarto.tv/(?P<channel>)[^&?/]+", re.VERBOSE)
 
 class Picarto(Plugin):
     @classmethod


### PR DESCRIPTION
Picarto recently changed their URL formats to be a lot less verbose, since old URLs don't work we need to update this to continue detecting picarto properly.