### PR TITLE
Titled streams

### DIFF
--- a/src/livestreamer/plugin/plugin.py
+++ b/src/livestreamer/plugin/plugin.py
@@ -315,5 +315,10 @@ class Plugin(object):
     def _get_streams(self):
         raise NotImplementedError
 
+    def stream_title(self):
+        return self._get_title()
+
+    def _get_title(self):
+        return None
 
 __all__ = ["Plugin"]

--- a/src/livestreamer/plugins/twitch.py
+++ b/src/livestreamer/plugins/twitch.py
@@ -228,6 +228,7 @@ class Twitch(Plugin):
         self.subdomain = match.get("subdomain")
         self.video_type = match.get("video_type")
         self.video_id = match.get("video_id")
+        self.title = None
 
         parsed = urlparse(url)
         self.params = parse_query(parsed.query)
@@ -381,6 +382,7 @@ class Twitch(Plugin):
         try:
             videos = self.api.videos(self.video_type + self.video_id,
                                      schema=_video_schema)
+            self.title = videos["title"]
         except PluginError as err:
             if "HTTP/1.1 0 ERROR" in str(err):
                 raise NoStreamsError(self.url)
@@ -452,5 +454,10 @@ class Twitch(Plugin):
         else:
             return self._get_hls_streams("live")
 
+    def _get_title(self):
+        if self.title is None:
+            info = self.api.channel_info(self.channel)
+            self.title = info["status"] + " - " + self.channel
+        return self.title
 
 __plugin__ = Twitch

--- a/src/livestreamer_cli/argparser.py
+++ b/src/livestreamer_cli/argparser.py
@@ -312,10 +312,14 @@ player.add_argument(
       It's usually "-" (stdin), but can also be a URL or a file
       depending on the options used.
 
+    title
+      The title of the specified stream if made available
+      by the stream's plugin, or the stream's URL otherwise.
+
     It's usually enough to use --player instead of this unless you
     need to add arguments after the filename.
 
-    Default is "{0}".
+    Default is '{0}'.
     """.format(DEFAULT_PLAYER_ARGUMENTS)
 )
 player.add_argument(

--- a/src/livestreamer_cli/constants.py
+++ b/src/livestreamer_cli/constants.py
@@ -4,7 +4,7 @@ from livestreamer import __version__ as LIVESTREAMER_VERSION
 
 from .compat import is_win32
 
-DEFAULT_PLAYER_ARGUMENTS = "--meta-title={title} {filename}"
+DEFAULT_PLAYER_ARGUMENTS = u"--meta-title={title} {filename}"
 
 if is_win32:
     APPDATA = os.environ["APPDATA"]

--- a/src/livestreamer_cli/constants.py
+++ b/src/livestreamer_cli/constants.py
@@ -4,7 +4,7 @@ from livestreamer import __version__ as LIVESTREAMER_VERSION
 
 from .compat import is_win32
 
-DEFAULT_PLAYER_ARGUMENTS = "{filename}"
+DEFAULT_PLAYER_ARGUMENTS = "--meta-title={title} {filename}"
 
 if is_win32:
     APPDATA = os.environ["APPDATA"]

--- a/src/livestreamer_cli/main.py
+++ b/src/livestreamer_cli/main.py
@@ -45,7 +45,7 @@ def check_file_output(filename, force):
     return FileOutput(filename)
 
 
-def create_output():
+def create_output(title=None):
     """Decides where to write the stream.
 
     Depending on arguments it can be one of these:
@@ -65,6 +65,9 @@ def create_output():
         out = FileOutput(fd=stdout)
     else:
         http = namedpipe = None
+
+        if title is None:
+            title = args.url
 
         if not args.player:
             console.exit("The default player (VLC) does not seem to be "
@@ -86,7 +89,7 @@ def create_output():
         out = PlayerOutput(args.player, args=args.player_args,
                            quiet=not args.verbose_player,
                            kill=not args.player_no_close,
-                           namedpipe=namedpipe, http=http)
+                           namedpipe=namedpipe, http=http, title=title)
 
     return out
 
@@ -239,7 +242,7 @@ def open_stream(stream):
     return stream_fd, prebuffer
 
 
-def output_stream(stream):
+def output_stream(stream, title=None):
     """Open stream, create output and finally write the stream to output."""
     global output
 
@@ -252,7 +255,7 @@ def output_stream(stream):
     else:
         return
 
-    output = create_output()
+    output = create_output(title=title)
 
     try:
         output.open()
@@ -329,6 +332,7 @@ def handle_stream(plugin, streams, stream_name):
 
     stream_name = resolve_stream_name(streams, stream_name)
     stream = streams[stream_name]
+    title = plugin.stream_title()
 
     # Print internal command-line if this stream
     # uses a subprocess.
@@ -378,7 +382,7 @@ def handle_stream(plugin, streams, stream_name):
             else:
                 console.logger.info("Opening stream: {0} ({1})", stream_name,
                                     stream_type)
-                success = output_stream(stream)
+                success = output_stream(stream, title=title)
 
             if success:
                 break

--- a/src/livestreamer_cli/output.py
+++ b/src/livestreamer_cli/output.py
@@ -117,7 +117,8 @@ class PlayerOutput(Output):
             cmd = cmd.replace("\\", "\\\\")
             args = args.replace("\\", "\\\\")
 
-        return shlex.split(cmd) + shlex.split(args)
+        split_args = map(lambda s: s.decode('utf8'), shlex.split(args.encode('utf8')))
+        return shlex.split(cmd) + split_args
 
     def _open(self):
         try:

--- a/src/livestreamer_cli/output.py
+++ b/src/livestreamer_cli/output.py
@@ -5,7 +5,7 @@ import sys
 
 from time import sleep
 
-from .compat import is_win32, stdout
+from .compat import is_win32, stdout, shlex_quote
 from .constants import DEFAULT_PLAYER_ARGUMENTS
 from .utils import ignored
 
@@ -66,12 +66,13 @@ class FileOutput(Output):
 class PlayerOutput(Output):
     def __init__(self, cmd, args=DEFAULT_PLAYER_ARGUMENTS,
                  filename=None, quiet=True, kill=True,
-                 call=False, http=False, namedpipe=None):
+                 call=False, http=False, namedpipe=None, title=None):
         self.cmd = cmd
         self.args = args
         self.kill = kill
         self.call = call
         self.quiet = quiet
+        self.title = title
 
         self.filename = filename
         self.namedpipe = namedpipe
@@ -105,7 +106,10 @@ class PlayerOutput(Output):
         else:
             filename = "-"
 
-        args = self.args.format(filename=filename)
+        if self.title is None:
+            self.title = filename
+
+        args = self.args.format(filename=filename, title=shlex_quote(self.title))
         cmd = self.cmd
         if is_win32:
             # We want to keep the backslashes on Windows as forcing the user to


### PR DESCRIPTION
This change allows plugins (Twitch is implemented) to specify a title for the stream they are outputting, which is passed to VLC to use as the video title if available.
