### PR TITLE
Add new parameter to Twitch usher URL

### DIFF
--- a/src/livestreamer/plugins/twitch.py
+++ b/src/livestreamer/plugins/twitch.py
@@ -133,6 +133,7 @@ class UsherService(object):
             "type": "any",
             "allow_source": "true",
             "allow_audio_only": "true",
+            "allow_spectre": "false",
         }
         params.update(extra_params)
 


### PR DESCRIPTION
Livestreamer was getting a "Player must be spectre-aware" error when it
tried to get the list of available HLS streams from some Twitch channels
(those playing a playlist?). To avoid this error, the usher service URL
now requires a new parameter called "allow_spectre" to be defined. Since
I don't know how this "spectre" thing works, I set the parameter to
"false".
