### PR TITLE
Update sideloading plugin cli documentation

### DIFF
--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -239,6 +239,8 @@ Unix-like (POSIX) $XDG_CONFIG_HOME/livestreamer/plugins
 Windows           %APPDATA%\\livestreamer\\plugins
 ================= ====================================================
 
+Alternatively, plugins will also be loaded from the :option:-`plugin-dirs`.
+
 .. note::
 
     If a plugin is added with the same name as a built-in plugin then


### PR DESCRIPTION
Add a mention of the "plugin-dirs" option as a way to allow sideloading plugins.
(I assume this is platform agnostic, I only tested on Mac OSX)
