### PR TITLE
Added hls seeking parameter and hls segment offset calculation

### DIFF
--- a/src/livestreamer/session.py
+++ b/src/livestreamer/session.py
@@ -49,6 +49,7 @@ class Livestreamer(object):
             "hls-segment-threads": 1,
             "hls-segment-timeout": 10.0,
             "hls-timeout": 60.0,
+            "hls-start-time": 0,
             "http-stream-timeout": 60.0,
             "ringbuffer-size": 1024 * 1024 * 16, # 16 MB
             "rtmp-timeout": 60.0,

--- a/src/livestreamer_cli/argparser.py
+++ b/src/livestreamer_cli/argparser.py
@@ -623,6 +623,16 @@ transport.add_argument(
     """
 )
 transport.add_argument(
+    "--hls-start-time",
+    type=num(int, min=0),
+    metavar="TIME",
+    help="""
+    Seeking time in seconds to start streaming. Used only for hls videos with ending token. 
+
+    Default is 0.
+    """
+)
+transport.add_argument(
     "--ringbuffer-size",
     metavar="SIZE",
     type=filesize,

--- a/src/livestreamer_cli/main.py
+++ b/src/livestreamer_cli/main.py
@@ -711,6 +711,9 @@ def setup_options():
     if args.hls_timeout:
         livestreamer.set_option("hls-timeout", args.hls_timeout)
 
+    if args.hls_start_time:
+        livestreamer.set_option("hls-start-time", args.hls_start_time)
+
     if args.hds_live_edge:
         livestreamer.set_option("hds-live-edge", args.hds_live_edge)
 


### PR DESCRIPTION
Feature request of #711

It adds parameter "--hls-start-time" which is then applied to hls videos with end token (e.g. Twitch VoD). It is approximate and tries to find nearest suitable segment, so there might be inaccuracies depending on size of segment.

It is useful when I don't want to use player pass-through, because then I would have stutters in video. This seems to fix it for me.
