### PR TITLE
Fix issue #1276 - ustream.tv KeyError: 'url'

### DIFF
--- a/src/livestreamer/plugins/ustreamtv.py
+++ b/src/livestreamer/plugins/ustreamtv.py
@@ -322,7 +322,7 @@ class UHSStreamWorker(SegmentedStreamWorker):
 
         chunk_id = int(result["chunkId"])
         chunk_offset = int(result["offset"])
-        chunk_range = dict(map(partial(map, int), chunk_range.items()))
+        chunk_range = {int(k): str(v) for k, v in chunk_range.items()}
 
         self.chunk_ranges.update(chunk_range)
         self.chunk_id_min = sorted(chunk_range)[0]

--- a/src/livestreamer/plugins/ustreamtv.py
+++ b/src/livestreamer/plugins/ustreamtv.py
@@ -510,8 +510,11 @@ class UStreamTV(Plugin):
         for provider in channel["stream"]:
             if provider["name"] == u"uhs_akamai":  # not heavily tested, but got a stream working
                 continue
-            provider_url = provider["url"]
-            provider_name = provider["name"]
+            try:
+                provider_url = provider["url"]
+                provider_name = provider["name"]
+            except KeyError:
+                continue
             for stream_index, stream_info in enumerate(provider["streams"]):
                 stream = None
                 stream_height = int(stream_info.get("height", 0))


### PR DESCRIPTION
in array channel["stream"] there are elements like:
{ 'varnishUrl': u'http://uhs-akamai.ustream.tv/ams/ams-uhs02/streams/httpflv/ustreamVideo/19983544/', 
'name': u'uhs_akamai' }
who do not have the key, "url". This patch skips such elements.
