### PR TITLE
Change url schema to match changes at periscope

### DIFF
--- a/src/livestreamer/plugins/periscope.py
+++ b/src/livestreamer/plugins/periscope.py
@@ -10,7 +10,7 @@ STREAM_INFO_URL = "https://api.periscope.tv/api/v2/getAccessPublic"
 STATUS_GONE = 410
 STATUS_UNAVAILABLE = (STATUS_GONE,)
 
-_url_re = re.compile(r"http(s)?://(www\.)?periscope.tv/w/(?P<broadcast_id>[\w\-\=]+)")
+_url_re = re.compile(r"http(s)?://(www\.)?periscope.tv/[^/]+/(?P<broadcast_id>[\w\-\=]+)")
 _stream_schema = validate.Schema(
     validate.any(
         None,


### PR DESCRIPTION
Livestreamer wouldn't recognise the Periscope url, because the url schema has changed. There is now the username in the url.
