### PR TITLE
Fixed weighting of Twitch stream names

### DIFF
--- a/src/livestreamer/plugin/plugin.py
+++ b/src/livestreamer/plugin/plugin.py
@@ -37,7 +37,7 @@ def stream_weight(stream):
         if stream in weights:
             return weights[stream], group
 
-    match = re.match("^(\d+)([k]|[p])?([\+])?$", stream)
+    match = re.match("^(\d+)([k]|[p])?(\d*)([\+])?$", stream)
 
     if match:
         if match.group(2) == "k":
@@ -53,7 +53,10 @@ def stream_weight(stream):
         elif match.group(2) == "p":
             weight = int(match.group(1))
 
-            if match.group(3) == "+":
+            if match.group(3):
+                weight += int(match.group(3))
+
+            if match.group(4) == "+":
                 weight += 1
 
             return weight, "pixels"


### PR DESCRIPTION
Twitch stream names now include framerate (e.g. 1080p→1080p60) and are not weighted correctly, breaking the ability to open the 'best' stream.

_edit_  
Apparently these new options are only available for a select few streams:  https://blog.twitch.tv/the-international-on-twitch-705404e95cc2

> For now, this set of Video Quality options will only be available on Valve’s TI6 streams

Perhaps this makes the importance of this change minimal but I wouldn't be surprised if more streams followed suit in the future.
