### PR TITLE
Change Fedora Package Manager from Yum  to Dnf

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -23,7 +23,7 @@ Distribution                         Installing
 `Exherbo Linux`_
 `Fedora`_                            .. code-block:: console
 
-                                        # yum install livestreamer
+                                        # dnf install livestreamer
 `FreeBSD (package)`_                 .. code-block:: console
 
                                         # pkg install multimedia/livestreamer


### PR DESCRIPTION
dnf is the current package manager in the latest Fedora version
