### PR TITLE
Allow windows users to use $HOME for their config

### DIFF
--- a/src/livestreamer_cli/constants.py
+++ b/src/livestreamer_cli/constants.py
@@ -8,7 +8,10 @@ DEFAULT_PLAYER_ARGUMENTS = "{filename}"
 
 if is_win32:
     APPDATA = os.environ["APPDATA"]
-    CONFIG_FILES = [os.path.join(APPDATA, "livestreamer", "livestreamerrc")]
+    CONFIG_FILES = [
+        os.path.join(APPDATA, "livestreamer", "livestreamerrc"),
+        os.path.expanduser("~/.livestreamerrc")
+    ]
     PLUGINS_DIR = os.path.join(APPDATA, "livestreamer", "plugins")
 else:
     XDG_CONFIG_HOME = os.environ.get("XDG_CONFIG_HOME", "~/.config")


### PR DESCRIPTION
Hey,

I know it's a tiny change, but this annoyed me for so long - having to use different locations for the config on my linux and windows machines.

Hope this injustice can be finally fixed
