### PR TITLE
Added Weights for New Quality Types

### DIFF
--- a/src/livestreamer/plugins/twitch.py
+++ b/src/livestreamer/plugins/twitch.py
@@ -24,6 +24,15 @@ QUALITY_WEIGHTS = {
     "medium": 480,
     "low": 240,
     "mobile": 120,
+     #Streams with FPS options use these weights
+    "1080p60": 1081,
+    "720p60": 721,
+    "720p30": 720,
+    "540p30": 540,
+    "480p30": 480,
+    "360p30": 360,
+    "240p30": 240,
+    "144p30": 144
 }
 
 


### PR DESCRIPTION
Certain streams use the following quality format "1080p60", ex RiotGames streams.
Identical weights (ex "high" and "720p30") shouldn't be an issue as streams either use the old format or the new one.