### PR TITLE
Update livecodingtv.py

### DIFF
--- a/src/livestreamer/plugins/livecodingtv.py
+++ b/src/livestreamer/plugins/livecodingtv.py
@@ -6,7 +6,7 @@ from livestreamer.plugin.api import http
 
 
 _rtmp_re = re.compile('rtmp://[^"]+/(?P<channel>\w+)+[^/"]+')
-_url_re = re.compile("http(s)?://(?:\w+.)?\livecoding\.tv")
+_url_re = re.compile("http(s)?://(?:\w+.)?livecoding\.tv")
 
 
 class LivecodingTV(Plugin):


### PR DESCRIPTION
Tried running livestreamer and got this error:
```
Failed to load plugin livecodingtv:
  File "/usr/lib/python3.6/imp.py", line 234, in load_module
    return load_source(name, filename, file)
  File "/usr/lib/python3.6/imp.py", line 172, in load_source
    module = _load(spec)
  File "<frozen importlib._bootstrap>", line 675, in _load
  File "<frozen importlib._bootstrap>", line 655, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 678, in exec_module
  File "<frozen importlib._bootstrap>", line 205, in _call_with_frames_removed
  File "/usr/lib/python3.6/site-packages/livestreamer/plugins/livecodingtv.py", line 9, in <module>
    _url_re = re.compile("http(s)?://(?:\w+.)?\livecoding\.tv")
  File "/usr/lib/python3.6/re.py", line 233, in compile
    return _compile(pattern, flags)
  File "/usr/lib/python3.6/re.py", line 301, in _compile
    p = sre_compile.compile(pattern, flags)
  File "/usr/lib/python3.6/sre_compile.py", line 562, in compile
    p = sre_parse.parse(p, flags)
  File "/usr/lib/python3.6/sre_parse.py", line 855, in parse
    p = _parse_sub(source, pattern, flags & SRE_FLAG_VERBOSE, 0)
  File "/usr/lib/python3.6/sre_parse.py", line 416, in _parse_sub
    not nested and not items))
  File "/usr/lib/python3.6/sre_parse.py", line 502, in _parse
    code = _escape(source, this, state)
  File "/usr/lib/python3.6/sre_parse.py", line 401, in _escape
    raise source.error("bad escape %s" % escape, len(escape))
sre_constants.error: bad escape \l at position 20
```

This patch solves the issue, though I'm not sure why there would be a backslash initially.