### PR TITLE
resolves #1643

### DIFF
--- a/src/livestreamer/plugins/youtube.py
+++ b/src/livestreamer/plugins/youtube.py
@@ -157,7 +157,7 @@ class YouTube(Plugin):
 
         params = {
             "video_id": video_id,
-            "el": "player_embedded"
+            "el": "detailpage"
         }
         res = http.get(API_VIDEO_INFO, params=params)
 


### PR DESCRIPTION
@ColasNahaboo noted that the folks at  [streamlink](https://github.com/streamlink/streamlink/issues/1421) fixed this issue using this. Perhaps worth integrating into livestreamer? 

p.s.: I have not exhaustively tested if there is any downside of this but: (1) fixes #1421 and (2) test streaming various (non-protected) youtube content, always worked as expected.